### PR TITLE
Move deps to hex pm, except shotgun

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,10 @@
 {erl_opts, [debug_info]}.
 {deps, [
-	{shotgun, {git, "git://github.com/inaka/shotgun.git", {branch, "master"}}},
-	{jsx, {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.9.0"}}},
-	{verl, {git, "https://github.com/jelly-beam/verl.git", {tag, "v1.0.1"}}},
-	{lru, {git, "git://github.com/barrel-db/erlang-lru.git", {tag, "1.3.1"}}},
-	{backoff, {git, "git://github.com/ferd/backoff.git", {tag, "1.1.6"}}}
+  {shotgun, {git, "git://github.com/inaka/shotgun.git", {branch, "master"}}},
+  {jsx, "2.9.0"},
+  {verl, "1.0.1"},
+  {lru, "1.3.1"},
+  {backoff, "1.1.6"}
 ]}.
 
 {shell, [


### PR DESCRIPTION
This switches most of the deps to depend on hex.pm. Solves most of https://github.com/launchdarkly/erlang-server-sdk/issues/4 , leaving the shotgun dep pointing to github until a new version is cut. A ticket was opened on the shotgun repo to try and get a new ver released https://github.com/inaka/shotgun/issues/179 .

This was tested with 2.6.4 and 3.12.0.