### PR TITLE
Point a majority of the dependencies to hex.pm

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,10 @@
 {erl_opts, [debug_info]}.
 {deps, [
-	{shotgun, {git, "git://github.com/inaka/shotgun.git", {branch, "master"}}},
-	{jsx, {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.9.0"}}},
-	{verl, {git, "https://github.com/jelly-beam/verl.git", {tag, "v1.0.1"}}},
-	{lru, {git, "git://github.com/barrel-db/erlang-lru.git", {tag, "1.3.1"}}},
-	{backoff, {git, "git://github.com/ferd/backoff.git", {tag, "1.1.6"}}}
+    {shotgun, {git, "git://github.com/inaka/shotgun.git", {branch, "master"}}},
+    {jsx, "2.9.0"},
+    {verl, "1.0.1"},
+    {lru, "1.3.1"},
+    {backoff, "1.1.6"}
 ]}.
 
 {shell, [


### PR DESCRIPTION
This PR addresses the first part of issue #4. 

Since Shotgun isn't pointing to a release, I left that dependency as is.