### PR TITLE
Accomodate for archived feature flag

### DIFF
--- a/src/eld_eval.erl
+++ b/src/eld_eval.erl
@@ -72,9 +72,15 @@ flag_recs_for_user(FlagKey, [], User, _StorageBackend, _Tag, DefaultValue) ->
     Reason = {error, flag_not_found},
     Events = [eld_event:new_for_unknown_flag(FlagKey, User, DefaultValue, Reason)],
     {{null, DefaultValue, Reason}, Events};
+flag_recs_for_user(FlagKey,[{FlagKey, #{<<"on">> := false}} | _], User, _StorageBackend, _Tag, DefaultValue) ->
+    % Flag found, but it's archived/not "on"
+    error_logger:warning_msg("Archived feature flag ~p; returning default value", [FlagKey]),
+    Reason = {error, flag_not_found},
+    Events = [eld_event:new_for_unknown_flag(FlagKey, User, DefaultValue, Reason)],
+    {{null, DefaultValue, Reason}, Events};
 flag_recs_for_user(FlagKey, [{FlagKey, #{<<"deleted">> := true}}|_], User, _StorageBackend, _Tag, DefaultValue) ->
     % Flag found, but it's deleted
-    error_logger:warning_msg("Unknown feature flag ~p; returning default value", [FlagKey]),
+    error_logger:warning_msg("Deleted feature flag ~p; returning default value", [FlagKey]),
     Reason = {error, flag_not_found},
     Events = [eld_event:new_for_unknown_flag(FlagKey, User, DefaultValue, Reason)],
     {{null, DefaultValue, Reason}, Events};


### PR DESCRIPTION
Hi,

When testing this LaunchDarkly lib, I came across a scenario which wasn't handled properly: when a flag was archived it would be returned as being not "on" by LD, which wasn't one of the scenarios in the code. This PR should fix that.

I'm a bit new to Erlang projects, I couldn't verify my change by running (& writing) tests, so if new tests need to be added, I'll need a few pointers on how to do that.

--- 
BTW, are the any areas this lib needs work? I'd like to use this lib for an upcoming Elixir project, so thanks in advance for the work you put into this :D