### PR TITLE
Use passed in Tag for fetching from storage backend.

### DIFF
--- a/src/eld.erl
+++ b/src/eld.erl
@@ -191,7 +191,7 @@ all_flags_state(User) ->
 -spec all_flags_state(User :: eld_user:user(), Tag :: atom()) -> feature_flags_state().
 all_flags_state(User, Tag) ->
     StorageBackend = eld_settings:get_value(Tag, storage_backend),
-    AllFlags = [FlagKey || {FlagKey, _} <- StorageBackend:list(default, flags)],
+    AllFlags = [FlagKey || {FlagKey, _} <- StorageBackend:list(Tag, flags)],
     EvalFun = fun(FlagKey, Acc) ->
         {{_, V, _}, _Events} = eld_eval:flag_key_for_user(Tag, FlagKey, User, null),
         Acc#{FlagKey => V}


### PR DESCRIPTION
Instead of using the `Tag` in the param it was hardcoded to `default` this fixes that and uses the passed in Tag value.

fixes https://github.com/launchdarkly/erlang-server-sdk/issues/10