### PR TITLE
Upgrade jsx to 3.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
   {shotgun, "0.5.0"},
-  {jsx, "2.9.0"},
+  {jsx, "3.1.0"},
   {verl, "1.0.1"},
   {lru, "1.3.1"},
   {backoff, "1.1.6"},


### PR DESCRIPTION
We're starting to see dependency conflicts due to a requirement in this project on jsx 2.9.0, this PR simply updates to jsx 3.0.0.