### PR TITLE
Fix bug around variationOrRollout when parsing rule

### DIFF
--- a/src/ldclient_rule.erl
+++ b/src/ldclient_rule.erl
@@ -48,9 +48,9 @@ match_user(#{clauses := Clauses}, User, FeatureStore, Tag) ->
 %%===================================================================
 
 -spec new_from_template(map()) -> rule().
-new_from_template(#{<<"id">> := Id, <<"clauses">> := Clauses, <<"trackEvents">> := TrackEvents, <<"variation">> := Variation}) ->
+new_from_template(#{<<"id">> := Id, <<"clauses">> := Clauses, <<"trackEvents">> := TrackEvents, <<"variationOrRollout">> := Variation}) when is_integer(Variation) ->
     #{id => Id, clauses => parse_clauses(Clauses), trackEvents => TrackEvents, variationOrRollout => Variation};
-new_from_template(#{<<"id">> := Id, <<"clauses">> := Clauses, <<"trackEvents">> := TrackEvents, <<"rollout">> := #{
+new_from_template(#{<<"id">> := Id, <<"clauses">> := Clauses, <<"trackEvents">> := TrackEvents, <<"variationOrRollout">> := #{
         <<"variations">> := Variations
     } = Rollout}) when is_list(Variations) ->
     #{


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

_Disclaimer: my evaluation below could be completely wrong due to lack of context and experience working with this library._

The LaunchDarkly Erlang SDK was expecting rules to have either a `variation` field or a `rollout` field. However, rules never have those fields and instead always have a field called `variationOrRollout` which is being completely ignored by this library. This was causing the library to effectively ignore all feature flag rules and always return the default value associated to a given feature flag, which defeats the purpose of this library.

This PR fixes it so that the library now looks for the `variationOrRollout` field instead of the `variation` or `rollout` fields.

