### PR TITLE
chore: add source link so Hex can pick it up

### DIFF
--- a/src/ldclient.app.src
+++ b/src/ldclient.app.src
@@ -24,5 +24,5 @@
   {modules, []},
 
   {licenses, ["Apache 2.0"]},
-  {links, []}
+  {links, [{"GitHub", "https://github.com/launchdarkly/erlang-server-sdk"}]}
  ]}.


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality -> N/A
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions -> -> N/A

**Related issues**

Hard to see where the project lives without the link to the source on hex.pm:
<img width="754" alt="image" src="https://github.com/launchdarkly/erlang-server-sdk/assets/8906358/e7d42c8e-f2e9-4254-98ea-189ea7347d6e">

Here is an example of a project that has the link (Github in this case):
<img width="621" alt="image" src="https://github.com/launchdarkly/erlang-server-sdk/assets/8906358/00cd6646-36e7-4fe8-99de-59074d648424">


**Describe the solution you've provided**

Leverage links from hex.pm as suggested in the docs:
<img width="1086" alt="image" src="https://github.com/launchdarkly/erlang-server-sdk/assets/8906358/2f55baab-e139-4df8-888d-52dc1114a402">


**Describe alternatives you've considered**

N/A

**Additional context**

Hi! No code change here, just adding a link to the hex.pm package. Thanks for your work!
