### PR TITLE
fix:  Changes for OTP 26.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         - {os: 'ubuntu-20.04', otp: '21.x', rebar: '3.15.2'}
         - {os: 'ubuntu-22.04', otp: '24.x', rebar: '3.18.0'}
         - {os: 'ubuntu-22.04', otp: '25.x', rebar: '3.18.0'}
+        - {os: 'ubuntu-22.04', otp: '26.x', rebar: '3.22.0'}
             
     runs-on: ${{ matrix.versions.os }}
     name: Build and Test - ${{ matrix.versions.otp }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/ci
+        env:
+          OTP_VER: ${{ matrix.versions.otp }}

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,6 @@ clean-redis:
 build-contract-tests:
 	@mkdir -p test-service/_checkouts
 	@rm -f $(CURDIR)/test-service/_checkouts/ldclient
-	@ln -sf $(CURDIR)/ $(CURDIR)/test-service/_checkouts/ldclient
-	@cd test-service && $(REBAR3) dialyzer
 	@cd test-service && $(REBAR3) as prod release
 
 start-contract-test-service:

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,17 @@ tls-tests:
 clean-redis:
 	docker rm --force ld-test-redis
 
+colon := :
 build-contract-tests:
 	@mkdir -p test-service/_checkouts
 	@rm -f $(CURDIR)/test-service/_checkouts/ldclient
+	@ln -sf $(CURDIR)/ $(CURDIR)/test-service/_checkouts/ldclient
+	@if [ "$(OTP_VER)" = "26.x" ]; then\
+		echo Dialyze for OTP 26;\
+		cd test-service && $(REBAR3) as otp26 dialyzer;\
+	else\
+		cd test-service && $(REBAR3) dialyzer;\
+	fi
 	@cd test-service && $(REBAR3) as prod release
 
 start-contract-test-service:

--- a/rebar.config
+++ b/rebar.config
@@ -32,6 +32,5 @@
 {ct_opts, [{ct_hooks, [cth_surefire]}]}.
 
 {dialyzer, [
-    {plt_apps, all_deps},
-    {plt_ignore_apps, [gun]}
+    {plt_apps, top_level_deps}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -30,3 +30,7 @@
 ]}.
 
 {ct_opts, [{ct_hooks, [cth_surefire]}]}.
+
+{dialyzer, [
+    {plt_apps, all_deps}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -32,5 +32,5 @@
 {ct_opts, [{ct_hooks, [cth_surefire]}]}.
 
 {dialyzer, [
-    {plt_apps, top_level_deps}
+    {plt_apps, all_deps}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -32,5 +32,6 @@
 {ct_opts, [{ct_hooks, [cth_surefire]}]}.
 
 {dialyzer, [
-    {plt_apps, all_deps}
+    {plt_apps, all_deps},
+    {plt_ignore_apps, [gun]}
 ]}.

--- a/src/ldclient_config.erl
+++ b/src/ldclient_config.erl
@@ -317,6 +317,10 @@ with_tls_revocation(Options) ->
             }
         } | Options].
 
+%% Disable warnings for tls_basic_certifi_options because the dialyzer
+%% cannot find certifi:cacerts.
+-dialyzer({nowarn_function, [tls_basic_certifi_options/0]}).
+
 %% @doc Provide basic TLS options using the bundled certifi store.
 %%
 %% @end

--- a/src/ldclient_event.erl
+++ b/src/ldclient_event.erl
@@ -74,7 +74,7 @@
     metric_value => number()
 }.
 
--export_type([event/0]).
+-export_type([event/0, event_data/0]).
 
 %%===================================================================
 %% API

--- a/src/ldclient_event_dispatch_httpc.erl
+++ b/src/ldclient_event_dispatch_httpc.erl
@@ -77,7 +77,7 @@ format_response(Version, StatusCode, ReasonPhrase) ->
     io_lib:format("~s ~b ~s", [Version, StatusCode, ReasonPhrase]).
 
 %% Get the server time, and if there is not time, then return 0.
--spec get_server_time(Headers :: httpc:headers()) -> integer().
+-spec get_server_time(Headers :: [{Field :: [byte()], Value :: binary() | iolist()}]) -> integer().
 get_server_time([{"date", Date}|_T]) when is_list(Date) ->
     %% convert_request_date expects a string that is a list of characters.
     %% Not a binary string. The guard can make sure it is a list, but not

--- a/src/ldclient_flagbuilder.erl
+++ b/src/ldclient_flagbuilder.erl
@@ -38,10 +38,10 @@
 -opaque flag_builder() :: #{
         key => binary(),
         on  => boolean(),
-        variations => [ldclient_flag:variations()],
+        variations => [ldclient_flag:variation_value()],
         off_variation => non_neg_integer(),
         fallthrough_variation => non_neg_integer(),
-        rules => [ldclient_rules:rule()],
+        rules => [ldclient_rule:rule()],
         context_targets => builder_targets()
 }. %% A builder for feature flag configurations to be used with {@link ldclient_testdata}.
 

--- a/src/ldclient_update_requestor.erl
+++ b/src/ldclient_update_requestor.erl
@@ -11,7 +11,7 @@
 -type response() :: {ok, binary() | not_modified}
                   | {error, errors()}.
 
--type errors() :: {bad_status, httpc:status_code(), string()}
+-type errors() :: {bad_status, non_neg_integer(), string()}
                 | network_error.
 
 -export_type([response/0, errors/0]).

--- a/src/ldclient_update_requestor_httpc.erl
+++ b/src/ldclient_update_requestor_httpc.erl
@@ -69,6 +69,10 @@ all(Uri, State) ->
 %% Internal functions
 %%===================================================================
 
--spec bad_status_error(StatusLine :: httpc:status_line()) -> ldclient_update_requestor:errors().
+-spec bad_status_error(StatusLine :: {
+    uri_string:uri_string(),
+    non_neg_integer(),
+    string()
+}) -> ldclient_update_requestor:errors().
 bad_status_error({Version, StatusCode, ReasonPhrase}) ->
     {bad_status, StatusCode, io_lib:format("~s ~b ~s", [Version, StatusCode, ReasonPhrase])}.

--- a/src/ldclient_update_stream_server.erl
+++ b/src/ldclient_update_stream_server.erl
@@ -20,7 +20,8 @@
     feature_store := atom(),
     storage_tag := atom(),
     stream_uri := string(),
-    gun_options := gun:opts(),
+    %% Try to use a proper type with Gun 2.0
+    gun_options := any(),
     headers := map()
 }.
 
@@ -156,7 +157,7 @@ do_listen_fail_backoff(Backoff, Code, Reason) ->
 %% @private
 %%
 %% @end
--spec do_listen(string(), atom(), atom(), GunOpts :: gun:opts(), Headers :: [{string(), string()}]) -> {ok, pid()} | {error, atom(), term()}.
+-spec do_listen(string(), atom(), atom(), GunOpts :: any, Headers :: [{string(), string()}]) -> {ok, pid()} | {error, atom(), term()}.
 do_listen(Uri, FeatureStore, Tag, GunOpts, Headers) ->
     {ok, {Scheme, Host, Port, Path, Query}} = ldclient_http:uri_parse(Uri),
     Opts = #{gun_opts => GunOpts},

--- a/src/ldclient_update_stream_server.erl
+++ b/src/ldclient_update_stream_server.erl
@@ -157,7 +157,7 @@ do_listen_fail_backoff(Backoff, Code, Reason) ->
 %% @private
 %%
 %% @end
--spec do_listen(string(), atom(), atom(), GunOpts :: any, Headers :: [{string(), string()}]) -> {ok, pid()} | {error, atom(), term()}.
+-spec do_listen(string(), atom(), atom(), GunOpts :: any(), Headers :: [{string(), string()}]) -> {ok, pid()} | {error, atom(), term()}.
 do_listen(Uri, FeatureStore, Tag, GunOpts, Headers) ->
     {ok, {Scheme, Host, Port, Path, Query}} = ldclient_http:uri_parse(Uri),
     Opts = #{gun_opts => GunOpts},

--- a/test-service/rebar.config
+++ b/test-service/rebar.config
@@ -17,8 +17,10 @@
     {apps, [ldclient, ts_app]}
 ]}.
 
-{profiles, [{prod, [{relx, [{dev_mode, false}
-    ,{include_erts, true}]}]}]}.
+{profiles, [
+    {prod, [{relx, [{dev_mode, false}
+    ,{include_erts, true}]}]}
+]}.
 
 {ct_opts, [{ct_hooks, [cth_surefire]}]}.
 
@@ -29,11 +31,4 @@
     {include_erts, false},
 
     {extended_start_script, true}]}.
-
-{dialyzer, [
-    {plt_apps, top_level_deps},
-    %% The dialyzer is not accounting for checkouts.
-    %% So for now we need to disable this.
-    {warnings, [no_unknown]}
-]}.
 

--- a/test-service/rebar.config
+++ b/test-service/rebar.config
@@ -19,7 +19,16 @@
 
 {profiles, [
     {prod, [{relx, [{dev_mode, false}
-    ,{include_erts, true}]}]}
+    ,{include_erts, true}]}]},
+    {otp26,
+    [
+        {dialyzer, [
+            {plt_apps, top_level_deps},
+            %% The dialyzer is not accounting for checkouts.
+            %% So for now we need to disable this.
+            {warnings, [no_unknown]}
+        ]}
+    ]}
 ]}.
 
 {ct_opts, [{ct_hooks, [cth_surefire]}]}.

--- a/test-service/rebar.config
+++ b/test-service/rebar.config
@@ -29,3 +29,11 @@
     {include_erts, false},
 
     {extended_start_script, true}]}.
+
+{dialyzer, [
+    {plt_apps, top_level_deps},
+    %% The dialyzer is not accounting for checkouts.
+    %% So for now we need to disable this.
+    {warnings, [no_unknown]}
+]}.
+


### PR DESCRIPTION
The code itself works in OTP 26, but the dialyzer now defaults to warning about unknowns.

This fixes a few real issues, and also ignores a false positive.

The version of gun we uses also has an unknown error, so we are only analyzing top level dependencies currently.
We may be able to change this with the gun 2.0 upgrade.