### PR TITLE
fix: update certifi dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
   {uuid, "2.0.2", {pkg, uuid_erl}},
   {eredis, "1.7.1"},
   {yamerl, "0.10.0"},
-  {certifi, "2.10.0"}
+  {certifi, "2.12.0"}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
**Requirements**

- [X] ~~I have added test coverage for new or changed functionality~~ validated that the same tests pass as did before at the previous release tag
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

I've simply updated `certifi` to the latest version

**Describe alternatives you've considered**

In my elixir project, I could just override the version of `certifi`. Maybe that's preferable?

**Additional context**

There's a conflict between the latest Hackney release and this project's `certifi` version