### PR TITLE
fix: Make gun open errors explicitly into temporary failures

### DIFF
--- a/src/ldclient_update_stream_server.erl
+++ b/src/ldclient_update_stream_server.erl
@@ -163,9 +163,9 @@ do_listen(Uri, FeatureStore, Tag, GunOpts, Headers) ->
     Opts = #{gun_opts => GunOpts},
     case shotgun:open(Host, Port, Scheme, Opts) of
         {error, gun_open_failed} ->
-            {error, gun_open_failed, "Could not open connection to host"};
+            {error, temporary, "Could not open connection to host"};
         {error, gun_open_timeout} ->
-            {error, gun_open_timeout, "Connection timeout"};
+            {error, temporary, "Connection timeout"};
         {ok, Pid} ->
             _ = monitor(process, Pid),
             F = fun(nofin, _Ref, Bin) ->


### PR DESCRIPTION
Updates `gun_open_*` failures during stream initialization to translate to `temporary` failures, as expected by the calling function.

I think these errors were always meant to be explicitly `temporary`. Otherwise, if these are currently returned the calling `try` block wouldn't pattern match and I believe it would crash the process. At that point we'd be relying on the supervisor restarts instead of managed backoff.