### PR TITLE
feat: add tlsv1.3 to default cipher suites

### DIFF
--- a/src/ldclient_config.erl
+++ b/src/ldclient_config.erl
@@ -395,6 +395,7 @@ get_all() ->
     {ok, Instances} = application:get_env(ldclient, instances),
     Instances.
 
+% OTP version 22 or greater is required for tls1.3 support.
 -if(?OTP_RELEASE >= 22).
 get_suites() ->
     ssl:cipher_suites(default, 'tlsv1.2') ++ ssl:cipher_suites(default, 'tlsv1.3').
@@ -405,7 +406,6 @@ get_suites() ->
 
 -spec tls_base_options() -> [ssl:tls_client_option()].
 tls_base_options() ->
-    % OTP version 22 or greater is requires for tls1.3 support.
     DefaultCipherSuites = get_suites(),
     CipherSuites = ssl:filter_cipher_suites(DefaultCipherSuites, [
         {key_exchange, fun

--- a/src/ldclient_config.erl
+++ b/src/ldclient_config.erl
@@ -395,13 +395,18 @@ get_all() ->
     {ok, Instances} = application:get_env(ldclient, instances),
     Instances.
 
+-if(?OTP_RELEASE >= 22).
+get_suites() ->
+    ssl:cipher_suites(default, 'tlsv1.2') ++ ssl:cipher_suites(default, 'tlsv1.3').
+-else.
+get_suites() ->
+    ssl:cipher_suites(default, 'tlsv1.2').
+-endif.
+
 -spec tls_base_options() -> [ssl:tls_client_option()].
 tls_base_options() ->
     % OTP version 22 or greater is requires for tls1.3 support.
-    DefaultCipherSuites = case erlang:list_to_integer(erlang:system_info(otp_release)) >= 22 of
-        true -> ssl:cipher_suites(default, 'tlsv1.2') ++ ssl:cipher_suites(default, 'tlsv1.3');
-        false -> ssl:cipher_suites(default, 'tlsv1.2')
-    end,
+    DefaultCipherSuites = get_suites(),
     CipherSuites = ssl:filter_cipher_suites(DefaultCipherSuites, [
         {key_exchange, fun
                            (ecdhe_ecdsa) -> true;

--- a/src/ldclient_config.erl
+++ b/src/ldclient_config.erl
@@ -397,7 +397,7 @@ get_all() ->
 
 -spec tls_base_options() -> [ssl:tls_client_option()].
 tls_base_options() ->
-    DefaultCipherSuites = ssl:cipher_suites(default, 'tlsv1.2'),
+    DefaultCipherSuites = ssl:cipher_suites(default, 'tlsv1.2', 'tlsv1.3'),
     CipherSuites = ssl:filter_cipher_suites(DefaultCipherSuites, [
         {key_exchange, fun
                            (ecdhe_ecdsa) -> true;

--- a/src/ldclient_config.erl
+++ b/src/ldclient_config.erl
@@ -397,7 +397,11 @@ get_all() ->
 
 -spec tls_base_options() -> [ssl:tls_client_option()].
 tls_base_options() ->
-    DefaultCipherSuites = ssl:cipher_suites(default, 'tlsv1.2', 'tlsv1.3'),
+    % OTP version 22 or greater is requires for tls1.3 support.
+    DefaultCipherSuites = case erlang:list_to_integer(erlang:system_info(otp_release)) >= 22 of
+        true -> ssl:cipher_suites(default, 'tlsv1.2') ++ ssl:cipher_suites(default, 'tlsv1.3');
+        false -> ssl:cipher_suites(default, 'tlsv1.2')
+    end,
     CipherSuites = ssl:filter_cipher_suites(DefaultCipherSuites, [
         {key_exchange, fun
                            (ecdhe_ecdsa) -> true;

--- a/src/ldclient_config.erl
+++ b/src/ldclient_config.erl
@@ -135,8 +135,10 @@
 
 -define(APPLICATION_DEFAULT_OPTIONS, undefined).
 
-%% OTP version 22 or greater is required for tls1.3 support.
--if(?OTP_RELEASE >= 22).
+%% Enable TLS 1.3 support for erlang 23 and higher.
+%% TLS 1.3 support stabilized during 22, but this implementation does not work in 22.0.
+%% To use TLS 1.3 with OTP 22, custom TLS options can be used.
+-if(?OTP_RELEASE >= 23).
 -define(MAX_SUPPORTED_TLS_VERSION, 'tlsv1.3').
 -define(SUPPORTED_TLS_VERSIONS, ['tlsv1.2', 'tlsv1.3']).
 -else.

--- a/src/ldclient_config.erl
+++ b/src/ldclient_config.erl
@@ -411,6 +411,8 @@ tls_base_options() ->
         {key_exchange, fun
                            (ecdhe_ecdsa) -> true;
                            (ecdhe_rsa) -> true;
+                           % Retain 'any' to prevent filtering 1.3 ciphers.
+                           (any) -> true;
                            (_) -> false
                        end
         },

--- a/test/ldclient_config_SUITE.erl
+++ b/test/ldclient_config_SUITE.erl
@@ -141,6 +141,7 @@ tls_basic_options(_) ->
         {verify, verify_peer},
         {ciphers, Ciphers},
         {depth, 3},
+        {versions, _Versions},
         {customize_hostname_check, _}] = BasicOptions,
         true = (length(Ciphers) =/= 0);
     false -> 
@@ -152,6 +153,7 @@ tls_basic_options(_) ->
                     {verify, verify_peer},
                     {ciphers, Ciphers},
                     {depth, 3},
+                    {versions, _Versions},
                     {customize_hostname_check, _}] = BasicOptions,
                 true = (length(Ciphers) =/= 0);
             {_, _} ->
@@ -160,6 +162,7 @@ tls_basic_options(_) ->
                     {verify, verify_peer},
                     {ciphers, Ciphers},
                     {depth, 3},
+                    {versions, _Versions},
                     {customize_hostname_check, _}] = BasicOptions,
                 true = (length(Ciphers) =/= 0)
         end

--- a/test/ldclient_config_SUITE.erl
+++ b/test/ldclient_config_SUITE.erl
@@ -174,6 +174,7 @@ tls_with_ca_certfile_options(_) ->
         {verify, verify_peer},
         {ciphers, Ciphers},
         {depth, 3},
+        {versions, _Versions},
         {customize_hostname_check, _}] = ldclient_config:tls_ca_certfile_options("imaginary/path/to/certfile.crt"),
     true = (length(Ciphers) =/= 0).
 
@@ -183,6 +184,7 @@ tls_basic_linux_options(_) ->
         {verify, verify_peer},
         {ciphers, Ciphers},
         {depth, 3},
+        {versions, _Versions},
         {customize_hostname_check, _}] = ldclient_config:tls_basic_linux_options(),
     true = (length(Ciphers) =/= 0).
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/erlang-server-sdk/issues/127

**Describe the solution you've provided**

SDK client should be able to connect successfully to a server presenting TLSv1.2 and TLSv1.3 cipher suites. 

**Describe alternatives you've considered**

Only support TLSv1.2 specifically. 


