### PR TITLE
feat: Add support for setting the redis username when using redis persistence.

### DIFF
--- a/src/ldclient_config.erl
+++ b/src/ldclient_config.erl
@@ -68,6 +68,7 @@
     redis_host => string(),
     redis_port => pos_integer(),
     redis_database => integer(),
+    redis_username => string() | undefined,
     redis_password => string(),
     redis_prefix => string(),
     redis_tls => [ssl:tls_option()] | undefined,
@@ -112,6 +113,7 @@
 -define(DEFAULT_REDIS_HOST, "127.0.0.1").
 -define(DEFAULT_REDIS_PORT, 6379).
 -define(DEFAULT_REDIS_DATABASE, 0).
+-define(DEFAULT_REDIS_USERNAME, undefined).
 -define(DEFAULT_REDIS_PASSWORD, "").
 -define(DEFAULT_REDIS_PREFIX, "launchdarkly").
 -define(DEFAULT_REDIS_TLS, undefined).
@@ -185,6 +187,7 @@ parse_options(SdkKey, Options) when is_list(SdkKey), is_map(Options) ->
     RedisHost = maps:get(redis_host, Options, ?DEFAULT_REDIS_HOST),
     RedisPort = maps:get(redis_port, Options, ?DEFAULT_REDIS_PORT),
     RedisDatabase = maps:get(redis_database, Options, ?DEFAULT_REDIS_DATABASE),
+    RedisUsername = maps:get(redis_username, Options, ?DEFAULT_REDIS_USERNAME),
     RedisPassword = maps:get(redis_password, Options, ?DEFAULT_REDIS_PASSWORD),
     RedisPrefix = maps:get(redis_prefix, Options, ?DEFAULT_REDIS_PREFIX),
     CacheTtl = maps:get(cache_ttl, Options, ?DEFAULT_CACHE_TTL),
@@ -218,6 +221,7 @@ parse_options(SdkKey, Options) when is_list(SdkKey), is_map(Options) ->
         redis_host => RedisHost,
         redis_port => RedisPort,
         redis_database => RedisDatabase,
+        redis_username => RedisUsername,
         redis_password => RedisPassword,
         redis_prefix => RedisPrefix,
         redis_tls => RedisTls,

--- a/src/ldclient_instance.erl
+++ b/src/ldclient_instance.erl
@@ -30,7 +30,7 @@
     redis_host => string(),
     redis_port => pos_integer(),
     redis_database => integer(),
-    redir_username => string() | undefined,
+    redis_username => string() | undefined,
     redis_password => string(),
     redis_prefix => string(),
     redis_tls => [ssl:tls_option()] | undefined,

--- a/src/ldclient_instance.erl
+++ b/src/ldclient_instance.erl
@@ -30,6 +30,7 @@
     redis_host => string(),
     redis_port => pos_integer(),
     redis_database => integer(),
+    redir_username => string() | undefined,
     redis_password => string(),
     redis_prefix => string(),
     redis_tls => [ssl:tls_option()] | undefined,

--- a/src/ldclient_storage_redis_server.erl
+++ b/src/ldclient_storage_redis_server.erl
@@ -57,11 +57,12 @@ init([Tag]) ->
     Host = ldclient_config:get_value(Tag, redis_host),
     Port = ldclient_config:get_value(Tag, redis_port),
     Database = ldclient_config:get_value(Tag, redis_database),
+    Username = ldclient_config:get_value(Tag, redis_username),
     Password = ldclient_config:get_value(Tag, redis_password),
     Prefix = ldclient_config:get_value(Tag, redis_prefix),
     TlsOpts = ldclient_config:get_value(Tag, redis_tls),
     BasicOpts = [
-        {host, Host}, {port, Port}, {database, Database}, {password, Password}
+        {host, Host}, {port, Port}, {database, Database}, {username, Username}, {password, Password}
     ],
     EredisOpts = set_tls_options(BasicOpts, TlsOpts),
     {ok, Client} = eredis:start_link(EredisOpts),
@@ -341,4 +342,3 @@ get_init(Client, Prefix) ->
         undefined -> false;
         _ -> true
     end.
-

--- a/test-usage/ldclient_usage.erl
+++ b/test-usage/ldclient_usage.erl
@@ -32,6 +32,7 @@ init_with_all_options() ->
         redis_host => "redis_host",
         redis_port => 9900,
         redis_database => 0,
+        redis_username => "username",
         redis_password => "password",
         redis_prefix => "prefix",
         redis_tls => [
@@ -69,4 +70,3 @@ use_variation_with_all_types_context() ->
             <<"object">> => #{<<"a">> => <<"b">>}
         },
         ldclient_context:new(<<"org-key">>, <<"org">>)))))))), false).
-


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

`eredis` supports taking in a username for connections in addition to the password. The default is `undefined`, which will remain unchanged unless `redis_password` is explicitly configured.