### PR TITLE
feat: Update certifi to 2.14.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
   {uuid, "2.0.2", {pkg, uuid_erl}},
   {eredis, "1.7.1"},
   {yamerl, "0.10.0"},
-  {certifi, "2.12.0"}
+  {certifi, "2.14.0"}
 ]}.
 
 {profiles, [

--- a/test-tls/ldclient_tls_options_SUITE.erl
+++ b/test-tls/ldclient_tls_options_SUITE.erl
@@ -23,7 +23,13 @@
     check_secure_default_shotgun_invalid/1,
     check_secure_default_shotgun_stream_endpoint_federal/1,
     check_secure_default_httpc_poll_endpoint_federal/1,
-    check_secure_default_httpc_events_endpoint_federal/1
+    check_secure_default_httpc_events_endpoint_federal/1,
+    check_certifi_shotgun_stream_endpoint/1,
+    check_certifi_shotgun_stream_endpoint_federal/1,
+    check_certifi_httpc_poll_endpoint/1,
+    check_certifi_httpc_poll_endpoint_federal/1,
+    check_certifi_httpc_events_endpoint/1,
+    check_certifi_httpc_events_endpoint_federal/1
 ]).
 
 %%====================================================================
@@ -44,7 +50,13 @@ all() ->
         check_secure_default_shotgun_invalid,
         check_secure_default_shotgun_stream_endpoint_federal,
         check_secure_default_httpc_poll_endpoint_federal,
-        check_secure_default_httpc_events_endpoint_federal
+        check_secure_default_httpc_events_endpoint_federal,
+        check_certifi_shotgun_stream_endpoint,
+        check_certifi_shotgun_stream_endpoint_federal,
+        check_certifi_httpc_poll_endpoint,
+        check_certifi_httpc_poll_endpoint_federal,
+        check_certifi_httpc_events_endpoint,
+        check_certifi_httpc_events_endpoint_federal
     ].
 
 init_per_suite(Config) ->
@@ -206,3 +218,53 @@ check_secure_default_shotgun_invalid(_) ->
         connect_timeout => undefined,
         custom_headers => undefined
     }, "LD_SDK_KEY").
+
+%% Using certifi
+
+check_certifi_shotgun_stream_endpoint(_) ->
+    {ok, _} = open_stream("https://stream.launchdarkly.com/all", #{
+        tls_options => ldclient_config:tls_basic_certifi_options(),
+        connect_timeout => undefined,
+        custom_headers => undefined
+    }, "LD_SDK_KEY").
+
+check_certifi_shotgun_stream_endpoint_federal(_) ->
+    {ok, _} = open_stream("https://stream.launchdarkly.us/all", #{
+        tls_options => ldclient_config:tls_basic_certifi_options(),
+        connect_timeout => undefined,
+        custom_headers => undefined
+    }, "LD_FED_SDK_KEY").
+
+check_certifi_httpc_poll_endpoint(_) ->
+    Options = [{ssl, ldclient_config:tls_basic_certifi_options()}],
+    {ok, _} = httpc:request(get, {"https://sdk.launchdarkly.com/sdk/latest-all", [
+        {"Authorization", os:getenv("LD_SDK_KEY")},
+        {"User-Agent", ldclient_config:get_user_agent()}
+    ]}, Options, []).
+
+check_certifi_httpc_poll_endpoint_federal(_) ->
+    Options = [{ssl, ldclient_config:tls_basic_certifi_options()}],
+    {ok, _} = httpc:request(get, {"https://sdk.launchdarkly.us/sdk/latest-all", [
+        {"Authorization", os:getenv("LD_FED_SDK_KEY")},
+        {"User-Agent", ldclient_config:get_user_agent()}
+    ]}, Options, []).
+
+check_certifi_httpc_events_endpoint(_) ->
+    Options = [{ssl, ldclient_config:tls_basic_certifi_options()}],
+    {ok, _} = httpc:request(post, {"https://events.launchdarkly.com/bulk", [
+        {"Authorization", os:getenv("LD_SDK_KEY")},
+        {"X-LaunchDarkly-Event-Schema", ldclient_config:get_event_schema()},
+        {"User-Agent", ldclient_config:get_user_agent()}],
+        "application/json",
+        <<"[{\"endDate\":1634839284004,\"features\":{\"test-boolean-flag\":{\"counters\":[{\"count\":1,\"unknown\":false,\"value\":true,\"variation\":0,\"version\":1}],\"default\":\"default-value\"}},\"kind\":\"summary\",\"startDate\":1634839284004},{\"creationDate\":1634839284004,\"kind\":\"index\",\"user\":{\"firstName\":\"Tester\",\"key\":\"12345-track\",\"lastName\":\"Testerson\",\"privateAttrs\":[]}}]">>
+    }, Options, []).
+
+check_certifi_httpc_events_endpoint_federal(_) ->
+    Options = [{ssl, ldclient_config:tls_basic_certifi_options()}],
+    {ok, _} = httpc:request(post, {"https://events.launchdarkly.us/bulk", [
+        {"Authorization", os:getenv("LD_FED_SDK_KEY")},
+        {"X-LaunchDarkly-Event-Schema", ldclient_config:get_event_schema()},
+        {"User-Agent", ldclient_config:get_user_agent()}],
+        "application/json",
+        <<"[{\"endDate\":1634839284004,\"features\":{\"test-boolean-flag\":{\"counters\":[{\"count\":1,\"unknown\":false,\"value\":true,\"variation\":0,\"version\":1}],\"default\":\"default-value\"}},\"kind\":\"summary\",\"startDate\":1634839284004},{\"creationDate\":1634839284004,\"kind\":\"index\",\"user\":{\"firstName\":\"Tester\",\"key\":\"12345-track\",\"lastName\":\"Testerson\",\"privateAttrs\":[]}}]">>
+    }, Options, []).


### PR DESCRIPTION
Regular update to ensure current certificate files when using certifi.

Extended the tls-tests to verify connections with certifi as well as default. (In some environments both tests will use certifi).