### PR TITLE
fix: Update to shotgun 1.2.1 to resolve issue with reconnections.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-  {shotgun, "1.1.0"},
+  {shotgun, "1.2.1"},
   {jsx, "3.1.0"},
   {verl, "1.0.1"},
   {lru, "2.4.0"},

--- a/src/ldclient_update_stream_server.erl
+++ b/src/ldclient_update_stream_server.erl
@@ -181,7 +181,7 @@ do_listen(Uri, FeatureStore, Tag, GunOpts, Headers) ->
                     error_logger:warning_msg("Streaming connection ended"),
                     shotgun:close(Pid)
                 end,
-            Options = #{async => true, async_mode => sse, handle_event => F},
+            Options = #{async => true, async_mode => sse, handle_event => F, allow_reconnect => false},
             case shotgun:get(Pid, Path ++ Query, Headers, Options) of
                 {error, Reason} ->
                     shotgun:close(Pid),


### PR DESCRIPTION
In shotgun 1.1.0 a new feature was introduced which introduced a bug with the SSE connection. Where previously it would close its process in all cases where it disconnected, now it would not do that in some situations. This caused #155.

We contributed an update to shotgun to allow disabling the feature for async connections where you need to monitor the connection state. https://github.com/inaka/shotgun/pull/203 

This was released in shotgun 1.2.1.

This PR updates to 1.2.1 and uses the option to disable the `reopen` feature added in shotgun 1.1.0.