### PR TITLE
ci: Include release version with SHA.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
         id: release
         with:
           command: manifest


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only change in the GitHub Actions workflow; the action ref (SHA) and behavior remain the same.
> 
> **Overview**
> Updates `.github/workflows/release-please.yml` to clarify the pinned `google-github-actions/release-please-action` version by changing the inline comment from `v3` to `v3.7.13` while keeping the same commit SHA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7df7b1beaa2a42895e788eba11a62ddc653f2743. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->