### PR TITLE
chore: Update cowlib for contract tests to work with OTP 28.

### DIFF
--- a/test-service/rebar.config
+++ b/test-service/rebar.config
@@ -9,9 +9,20 @@
     {eredis, "1.7.1"},
     {yamerl, "0.10.0"},
     {certifi, "2.12.0"},
-    {cowboy, "2.8.0"},
+    {cowboy, "2.14.2"},
     ldclient
 ]}.
+
+%% Overridden for: https://github.com/ninenines/cowboy/issues/1670
+%% Could be removed in the future once we are confident in newer versions
+%% of rebar3 being available.
+{overrides,
+  [
+    {override, cowboy,
+      [{deps, [cowlib, ranch]}]
+    }
+  ]
+}.
 
 {shell, [
     {apps, [ldclient, ts_app]}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency upgrade of the HTTP server library plus overridden dependency resolution could introduce subtle runtime or build differences in the test service, especially around Cowboy/Ranch integration.
> 
> **Overview**
> Updates `test-service` to use `cowboy` `2.14.2` (from `2.8.0`) to improve compatibility with newer OTP versions.
> 
> Adds a `rebar.config` `overrides` block that forces `cowboy` to resolve with `cowlib` and `ranch`, as a workaround for ninenines/cowboy#1670 and older `rebar3` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a1e03fe8a5412715010b67392e79eca091e374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->