### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`.

The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml` was updated ([gh-actions#86](https://github.com/launchdarkly/gh-actions/pull/86)) to declare `permissions: pull-requests: read` at the job level. A reusable workflow can only request a subset of the permissions the caller grants, so without an explicit `permissions` block in the caller, the workflow fails with `startup_failure`. Same fix as [sdk-meta#429](https://github.com/launchdarkly/sdk-meta/pull/429).

## Review & Testing Checklist for Human

- [ ] Verify the `Lint PR title` workflow run on this PR succeeds (exits `success` rather than `startup_failure`)

### Notes

No product code is changed — this is a workflow-only permissions fix.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that just adds explicit `pull-requests: read` permissions to allow the reusable lint workflow to start.
> 
> **Overview**
> Fixes the `Lint PR title` GitHub Action by explicitly granting **workflow-level** `permissions: pull-requests: read`, so the reusable `launchdarkly/gh-actions` lint workflow can request the needed permission and avoid `startup_failure`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9862c8093af8cb7ac74e36533c94d8f220770ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->