### PR TITLE
fix: Fix apache license format

### DIFF
--- a/src/ldclient.app.src
+++ b/src/ldclient.app.src
@@ -23,6 +23,6 @@
   {env,[]},
   {modules, []},
 
-  {licenses, ["Apache 2.0"]},
+  {licenses, ["Apache-2.0"]},
   {links, [{"GitHub", "https://github.com/launchdarkly/erlang-server-sdk"}]}
  ]}.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single metadata string change with no runtime or security impact.
> 
> **Overview**
> Updates the OTP application metadata in `ldclient.app.src` so the `licenses` field uses the SPDX identifier **`Apache-2.0`** instead of **`Apache 2.0`**, aligning with standard license tagging for packaging and tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffab6dad8386da7416c965472fda61512564735c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->