### PR TITLE
feat: Update rebar config, use shotgun ~> 1.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-  {shotgun, "1.2.1"},
+  {shotgun, "~> 1.2"},
   {jsx, "3.1.0"},
   {verl, "1.0.1"},
   {lru, "2.4.0"},


### PR DESCRIPTION
## Description

This version of `shotgun` brings in `gun` 2.2, which has multiple
CVEs, causing app authors to be aware and explicitly override `gun`
or `shotgun`.

## Changes

Update rebar.config to use `shotgun` `~> 1.2`.

Before
```
$ rebar3 tree
└─ ldclient─3.10.1 (project app)
   ...
   ├─ shotgun─1.2.1 (hex package)
   │  └─ gun─2.2.0 (hex package) <- vulnerable
   │     └─ cowlib─2.17.1 (hex package)
   ...
```

With this change
```
$ rebar3 tree
└─ ldclient─3.10.1 (project app)
   ...
   ├─ shotgun─1.2.2 (hex package)
   │  └─ gun─2.4.1 (hex package) <- ok
   │     └─ cowlib─2.17.1 (hex package)
   ...
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line rebar dependency constraint change with no Erlang source edits; risk is limited to minor HTTP client library behavior differences in shotgun/gun.
> 
> **Overview**
> **Dependency-only change** in `rebar.config`: `shotgun` moves from a pinned `1.2.1` to **`~> 1.2`**, so rebar can resolve a newer 1.2.x release.
> 
> That pulls **`gun` 2.4.1** (via shotgun 1.2.2) instead of **`gun` 2.2.0**, which had known CVEs and often forced downstream apps to override `gun` or `shotgun` explicitly. HTTP/SSE behavior still goes through shotgun; this is a transitive security bump, not an application code change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb2c900f8bb5fc09cdeff39e84aeffa14be48fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->