### PR TITLE
feat: Ensure shotgun dependency is at least 1.2.2.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-  {shotgun, "~> 1.2"},
+  {shotgun, "~> 1.2.2"},
   {jsx, "3.1.0"},
   {verl, "1.0.1"},
   {lru, "2.4.0"},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency constraint-only change with no logic changes; low risk unless 1.2.2 introduces breaking behavior in shotgun itself.
> 
> **Overview**
> Tightens the **shotgun** HTTP client dependency in `rebar.config` from `~> 1.2` to **`~> 1.2.2`**, so builds resolve at least version 1.2.2. No application or test code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f45f20a9af216e51ac17addd5e07a672978b4728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->