### PR TITLE
Brent pla 1693 more logging and v3.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - { otp: "24.3.4.17", rebar: "e008a2ff40f708494a7c259a1fd8c2e77f7cd6a0" } # rebar 3.17.0
           - { otp: "25.3.2.19", rebar: "174fd9070195443d693d444ecd1f2b7aa91661fe" } # rebar 3.18.0
           - { otp: "27.3.2", rebar: "bde4b54248d16280b2c70a244aca3bb7566e2033" } # rebar 3.23.0
+          - { otp: "28.4.1", rebar: "619df55d9dab109cbd1b5d9ed1d45c93f5450e24" } # rebar 3.27.0
 
     runs-on: ubuntu-24.04
     name: Build and Test - ${{ matrix.versions.otp }}

--- a/src/ldclient_update_stream_server.erl
+++ b/src/ldclient_update_stream_server.erl
@@ -8,6 +8,8 @@
 
 -behaviour(gen_server).
 
+-include_lib("kernel/include/logger.hrl").
+
 %% Supervision
 -export([start_link/1, init/1]).
 
@@ -49,6 +51,7 @@ start_link(Tag) ->
     {ok, State :: state()} | {ok, State :: state(), timeout() | hibernate} |
     {stop, Reason :: term()} | ignore.
 init([Tag]) ->
+    logger:set_process_metadata(#{module => ?MODULE}),
     StreamUri = ldclient_config:get_value(Tag, stream_uri) ++ "/all",
     FeatureStore = ldclient_config:get_value(Tag, feature_store),
     HttpOptions = ldclient_config:get_value(Tag, http_options),
@@ -89,6 +92,18 @@ handle_info({listen}, #{stream_uri := Uri} = State) ->
     error_logger:info_msg("Starting streaming connection to URL: ~p", [Uri]),
     NewState = do_listen(State),
     {noreply, NewState};
+handle_info(check_shotgun_state, #{conn := undefined} = State) ->
+    ?LOG_INFO("Skipping silent failure polling until we can re-establish a Shotgun connection"),
+    {noreply, State};
+handle_info(check_shotgun_state, #{conn := ShotgunPid} = State) ->
+    case sys:get_state(ShotgunPid) of
+        {down, _} ->
+            ?LOG_WARNING("Shotgun is in the 'down' state, but ldclient hasn't detected that yet");
+        _ ->
+            ok
+    end,
+    erlang:send_after(1000, self(), {check_shotgun_state}),
+    {noreply, State};
 handle_info({'DOWN', _Mref, process, ShotgunPid, Reason}, #{conn := ShotgunPid, backoff := Backoff} = State) ->
     NewBackoff = ldclient_backoff:fail(Backoff),
     _ = ldclient_backoff:fire(NewBackoff),
@@ -140,6 +155,8 @@ do_listen(#{
             State;
         {ok, Pid} ->
             NewBackoff = ldclient_backoff:succeed(Backoff),
+            ?LOG_INFO("Established Shotgun connection"),
+            erlang:send_after(1000, self(), check_shotgun_state),
             State#{conn := Pid, backoff := NewBackoff}
         catch Code:_Reason ->
             % Don't pass raw exception reason as it could contain unsafe data
@@ -182,7 +199,9 @@ do_listen(Uri, FeatureStore, Tag, GunOpts, Headers) ->
                         error_logger:warning_msg("Invalid SSE event error (~p)", [Code]),
                         shotgun:close(Pid)
                     end;
-                (fin, _Ref, _Bin) ->
+                (fin, _Ref, Bin) ->
+                    ?LOG_INFO("ldclient received a 'FIN' SSE and ignored the data it contains, which is: ~p", [Bin]),
+
                     % Connection ended, close monitored shotgun client pid, so we can reconnect
                     error_logger:warning_msg("Streaming connection ended"),
                     shotgun:close(Pid)
@@ -316,7 +335,7 @@ maybe_patch_item(FeatureStore, Tag, Bucket, Key, Item, ParseFunction) ->
 -spec maybe_delete_item(atom(), atom(), atom(), binary(), pos_integer()|undefined) -> ok.
 maybe_delete_item(FeatureStore, Tag, Bucket, Key, NewVersion) ->
     case FeatureStore:get(Tag, Bucket, Key) of
-        [] -> 
+        [] ->
             NewDeletedFlag = ldclient_flag:new(#{<<"key">> => Key, <<"deleted">> => true, <<"version">> => NewVersion}),
             NewItem = #{Key => NewDeletedFlag},
             FeatureStore:upsert(Tag, Bucket, NewItem);


### PR DESCRIPTION
**Describe the solution you've provided**
Add additional logging and updated otp version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch the live streaming reconnect path and may log SSE FIN payloads; CI-only OTP addition is low risk but expands the compatibility surface.
> 
> **Overview**
> Adds **OTP 28.4.1** (with matching rebar) to the GitHub Actions build matrix so the SDK is tested on the newest supported Erlang.
> 
> In **`ldclient_update_stream_server`**, observability around the LaunchDarkly SSE/Shotgun path is expanded: the process sets **logger metadata** on init, logs when a Shotgun connection is established, and starts a **1s `check_shotgun_state` poll** that warns if Shotgun is `{down, _}` before the client’s `DOWN` handling kicks in (with an info log when there is no connection to poll). SSE **`fin`** callbacks now log the ignored payload via `?LOG_INFO` before closing and reconnecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed3fc1134be9b4e8da6c164d191bf146e89a7a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->