### PR TITLE
fix: Close streaming connection promptly when client is closed

### DIFF
--- a/src/ldclient_update_stream_server.erl
+++ b/src/ldclient_update_stream_server.erl
@@ -16,6 +16,7 @@
 
 -type state() :: #{
     conn := pid() | undefined,
+    gun_conn := pid() | undefined,
     backoff := ldclient_backoff:backoff(),
     feature_store := atom(),
     storage_tag := atom(),
@@ -61,6 +62,7 @@ init([Tag]) ->
     process_flag(trap_exit, true),
     State = #{
         conn => undefined,
+        gun_conn => undefined,
         backoff => Backoff,
         feature_store => FeatureStore,
         storage_tag => Tag,
@@ -95,7 +97,7 @@ handle_info({'DOWN', _Mref, process, ShotgunPid, Reason}, #{conn := ShotgunPid, 
     % Reason from DOWN message could contain connection details with headers/SDK keys
     SafeReason = ldclient_key_redaction:format_shotgun_error(Reason),
     error_logger:warning_msg("Got DOWN message from shotgun pid with reason: ~s, will retry in ~p ms~n", [SafeReason, maps:get(current, NewBackoff)]),
-    {noreply, State#{conn := undefined, backoff := NewBackoff}};
+    {noreply, State#{conn := undefined, gun_conn := undefined, backoff := NewBackoff}};
 handle_info({timeout, _TimerRef, listen}, State) ->
     error_logger:info_msg("Reconnecting streaming connection...~n"),
     NewState = do_listen(State),
@@ -108,9 +110,9 @@ handle_info(_Info, State) ->
 terminate(Reason, #{conn := undefined} = _State) ->
     error_logger:info_msg("Terminating, reason: ~p; Pid none~n", [Reason]),
     ok;
-terminate(Reason, #{conn := ShotgunPid} = _State) ->
+terminate(Reason, #{conn := ShotgunPid, gun_conn := GunPid} = _State) ->
     error_logger:info_msg("Terminating streaming connection, reason: ~p; Pid ~p~n", [Reason, ShotgunPid]),
-    ok = shotgun:close(ShotgunPid).
+    force_close(ShotgunPid, GunPid).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -138,9 +140,9 @@ do_listen(#{
             % or an integer status code from the do_listen/5 method.
             error_logger:error_msg("Stream encountered permanent error ~p, giving up~n", [Reason]),
             State;
-        {ok, Pid} ->
+        {ok, Pid, GunPid} ->
             NewBackoff = ldclient_backoff:succeed(Backoff),
-            State#{conn := Pid, backoff := NewBackoff}
+            State#{conn := Pid, gun_conn := GunPid, backoff := NewBackoff}
         catch Code:_Reason ->
             % Don't pass raw exception reason as it could contain unsafe data
             NewBackoff = do_listen_fail_backoff(Backoff, Code, "unexpected exception"),
@@ -162,7 +164,7 @@ do_listen_fail_backoff(Backoff, Code, Reason) ->
 %% @private
 %%
 %% @end
--spec do_listen(string(), atom(), atom(), GunOpts :: any(), Headers :: [{string(), string()}]) -> {ok, pid()} | {error, atom(), term()}.
+-spec do_listen(string(), atom(), atom(), GunOpts :: any(), Headers :: [{string(), string()}]) -> {ok, pid(), pid() | undefined} | {error, atom(), term()}.
 do_listen(Uri, FeatureStore, Tag, GunOpts, Headers) ->
     {ok, {Scheme, Host, Port, Path, Query}} = ldclient_http:uri_parse(Uri),
     Opts = #{gun_opts => GunOpts},
@@ -173,6 +175,7 @@ do_listen(Uri, FeatureStore, Tag, GunOpts, Headers) ->
             {error, temporary, "Connection timeout"};
         {ok, Pid} ->
             _ = monitor(process, Pid),
+            GunPid = gun_connection_pid(Pid),
             F = fun(nofin, _Ref, Bin) ->
                     try
                         process_event(parse_shotgun_event(Bin), FeatureStore, Tag)
@@ -180,24 +183,64 @@ do_listen(Uri, FeatureStore, Tag, GunOpts, Headers) ->
                         % Exception when processing event - don't log exception details
                         % as they could theoretically contain sensitive data
                         error_logger:warning_msg("Invalid SSE event error (~p)", [Code]),
-                        shotgun:close(Pid)
+                        force_close(Pid, GunPid)
                     end;
                 (fin, _Ref, _Bin) ->
                     % Connection ended, close monitored shotgun client pid, so we can reconnect
                     error_logger:warning_msg("Streaming connection ended"),
-                    shotgun:close(Pid)
+                    force_close(Pid, GunPid)
                 end,
             Options = #{async => true, async_mode => sse, handle_event => F, allow_reconnect => false},
             case shotgun:get(Pid, Path ++ Query, Headers, Options) of
                 {error, Reason} ->
-                    shotgun:close(Pid),
+                    force_close(Pid, GunPid),
                     SafeReason = ldclient_key_redaction:format_shotgun_error(Reason),
                     {error, temporary, SafeReason};
                 {ok, #{status_code := StatusCode}} when StatusCode >= 400 ->
+                    force_close(Pid, GunPid),
                     {error, ldclient_http:is_http_error_code_recoverable(StatusCode), StatusCode};
                 {ok, _Ref} ->
-                    {ok, Pid}
+                    {ok, Pid, GunPid}
             end
+    end.
+
+%% @doc Get the pid of the gun connection owned by a shotgun client.
+%% @private
+%%
+%% shotgun does not expose its underlying gun connection, but tearing the
+%% TCP connection down promptly requires closing the gun connection itself,
+%% so we read the pid out of the shotgun process state. This must not be
+%% called from code running inside the shotgun process (such as the
+%% handle_event fun), where sys:get_state would block on itself.
+%% @end
+-spec gun_connection_pid(ShotgunPid :: pid()) -> pid() | undefined.
+gun_connection_pid(ShotgunPid) ->
+    try sys:get_state(ShotgunPid) of
+        {_StateName, #{pid := GunPid}} when is_pid(GunPid) -> GunPid;
+        _ -> undefined
+    catch
+        _:_ -> undefined
+    end.
+
+%% @doc Close a streaming connection, releasing the TCP socket immediately.
+%% @private
+%%
+%% shotgun:close/1 asks gun for a graceful shutdown, and gun defers a
+%% graceful shutdown until its in-flight streams finish. The SSE stream
+%% never finishes, so that alone leaves the socket established until the
+%% owning processes are garbage collected. Closing the gun connection
+%% directly tears the socket down right away. The shutdown message to the
+%% shotgun client is queued first, so it stops cleanly before it can react
+%% to the gun connection going down.
+%% @end
+-spec force_close(ShotgunPid :: pid(), GunPid :: pid() | undefined) -> ok.
+force_close(ShotgunPid, GunPid) ->
+    ok = shotgun:close(ShotgunPid),
+    case GunPid of
+        undefined -> ok;
+        _ ->
+            _ = gun:close(GunPid),
+            ok
     end.
 
 %% @doc Processes server-sent event received from shotgun

--- a/test-service/rebar.config
+++ b/test-service/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-    {shotgun, "1.0.1"},
+    {shotgun, "1.2.2"},
     {jsx, "3.1.0"},
     {verl, "1.0.1"},
     {lru, "2.4.0"},
@@ -20,6 +20,11 @@
   [
     {override, cowboy,
       [{deps, [cowlib, ranch]}]
+    },
+    %% Same workaround as cowboy above: gun's cowlib requirement is a
+    %% version range that rebar3 cannot parse.
+    {override, gun,
+      [{deps, [cowlib]}]
     }
   ]
 }.


### PR DESCRIPTION
## Summary

When the client is closed, the streaming TCP connection was left established until process garbage collection. `ldclient_update_stream_server:terminate/2` calls `shotgun:close/1`, but shotgun implements close as `gun:shutdown/1` — a *graceful* shutdown that waits for in-flight streams to finish. The SSE stream never finishes, so the socket never closes. This fails the new connection-lifecycle contract test proposed in sdk-test-harness PR launchdarkly/sdk-test-harness#377 (`streaming/connection lifecycle/SDK closes streaming connection when client is closed`); every other server SDK at latest release passes it.

The fix captures the gun connection pid when the stream is opened (via `sys:get_state/1` on the shotgun client — shotgun does not expose it) and adds `force_close/2`, which calls `shotgun:close/1` and then `gun:close/1` (immediate teardown via `supervisor:terminate_child`). The shutdown message to the shotgun client is queued before the gun connection dies, so the client stops cleanly before it can react to the connection going down. `sys:get_state` is guarded (pattern match + catch) and the close path degrades to today's behavior if the pid can't be read; it is deliberately never called from the `handle_event` fun, which runs inside the shotgun process and would block on itself.

`force_close` is used at every teardown site:

- `terminate/2` (client shutdown — the contract-test failure)
- both `handle_event` close paths (invalid-event and stream-ended reconnects previously leaked the old socket per retry)
- the `shotgun:get` error path
- **the `>= 400` response path, which previously never closed the connection at all** — each backoff retry leaked a shotgun client plus its gun connection

## Test service dependency correction

Second commit: the test service pinned `shotgun 1.0.1` at top level, which wins rebar3 resolution over the SDK's `~> 1.2.2` requirement — so contract tests were exercising a dependency set real applications cannot resolve. Bumped to 1.2.2 (resolves gun 2.2.0). This needed a `gun` deps override mirroring the existing cowboy one, because gun 2.2's cowlib requirement is a version range rebar3 cannot parse. Note: shotgun 1.2.2 alone does **not** fix the leak — see validation below.

## Validation

All runs used the harness built from launchdarkly/sdk-test-harness#377 with `-run 'streaming/connection lifecycle'`:

| Configuration | Result |
|---|---|
| main + shotgun 1.0.1 (current test-service pin) | FAIL 3/3 |
| main + shotgun 1.2.2 / gun 2.2.0 | FAIL 3/3 (dep bump alone is not a fix) |
| fixed + shotgun 1.0.1 | PASS 3/3 |
| fixed + shotgun 1.2.2 / gun 2.2.0 | PASS 3/3 |

Regression checks on the fixed SDK: full contract-test suite (no suppressions, as CI runs it) — **6295 ran, all passed**; `make tests` (CT incl. Redis suites) — all 342 passed; SDK dialyzer (`make dialyze`) and test-service dialyzer (`as otp26`, as CI runs it) both clean.

SDK-2830